### PR TITLE
Only use torch.compile when inductor is available

### DIFF
--- a/cube3d/model/autoencoder/one_d_autoencoder.py
+++ b/cube3d/model/autoencoder/one_d_autoencoder.py
@@ -135,7 +135,7 @@ class OneDEncoder(nn.Module):
 
         init_tfixup(self, num_layers)
 
-    @torch.compile(fullgraph=True) if sys.platform == "linux" else lambda x: x
+    @torch.compile(fullgraph=True) if 'inductor' in torch._dynamo.list_backends() else lambda x: x
     def _forward(self, h, data, attn_mask=None):
         """
         Forward pass for the autoencoder model.
@@ -268,7 +268,8 @@ class OneDDecoder(nn.Module):
 
         init_tfixup(self, num_layers)
 
-    @torch.compile(fullgraph=True) if sys.platform == "linux" else lambda x: x
+    
+    @torch.compile(fullgraph=True) if 'inductor' in torch._dynamo.list_backends() else lambda x: x
     def _forward(self, h):
         """
         Applies a sequence of operations to the input tensor `h` using the blocks

--- a/cube3d/model/autoencoder/spherical_vq.py
+++ b/cube3d/model/autoencoder/spherical_vq.py
@@ -62,7 +62,8 @@ class SphericalVectorQuantizer(nn.Module):
         return self.norm(self.cb_norm(self.codebook.weight))
 
     @torch.no_grad()
-    @torch.compile(fullgraph=True) if sys.platform == "linux" else lambda x: x
+
+    @torch.compile(fullgraph=True) if 'inductor' in torch._dynamo.list_backends() else lambda x: x
     def lookup_codebook(self, q: torch.Tensor):
         """
         Perform a lookup in the codebook and process the result.


### PR DESCRIPTION
Conditional use of `torch.compile` when the appropriate backend is available. 