### PR TITLE
Minor update to clarify Blender version

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ and save it as `turntable.gif` in the specified `output` directory.
 
 We provide several example output objects and their corresponding text prompts in the `examples` folder.
 
-> **Note**: You must have Blender installed and available in your system's PATH to render the turntable GIF. You can download it from [Blender's official website](https://www.blender.org/). Ensure that the Blender executable is accessible from the command line.
+> **Note**: You must have Blender (version >= 4.3) installed and available in your system's PATH to render the turntable GIF. You can download it from [Blender's official website](https://www.blender.org/). Ensure that the Blender executable is accessible from the command line.
 
 > **Note**: If shape decoding is slow, you can try to specify a lower resolution using the `--resolution-base` flag. A lower resolution will create a coarser and lower quality output mesh but faster decoding. Values between 4.0 and 9.0 are recommended.
 


### PR DESCRIPTION
The default `apt install blender` comes with 4.0.x and won't work