### PR TITLE
Assert for cuda devices in EngineFast

### DIFF
--- a/cube3d/inference/engine.py
+++ b/cube3d/inference/engine.py
@@ -304,6 +304,10 @@ class EngineFast(Engine):
             device (torch.device): The device to run the inference on (e.g., CPU or CUDA).
         """
 
+        assert (
+            device.type == "cuda"
+        ), "EngineFast is only supported on cuda devices, please use Engine on non-cuda devices"
+
         super().__init__(config_path, gpt_ckpt_path, shape_ckpt_path, device)
 
         # CUDA Graph params


### PR DESCRIPTION
## 🔥 Summary
Fail fast if EngineFast is called on non-cuda devices

## 📖 📷 Additional context
EngineFast uses CUDA Graphs which will not work on non-cuda devices. Fail early instead of waiting for us to hit the CUDA Graph part

## 🛠 Testing instructions
# Tested on a cuda device to get outputs
```
cube$ python -m cube3d.generate             --gpt-ckpt-path model_weights/shape_gpt.safetensors             --shape-ckpt-path model_weights/shape_tokenizer.safetensors             --fast-inference             --prompt "Broad-winged flying red dragon, elongated, folded legs." --disable-postprocessing
Using device: cuda
Using cuda graphs, this will take some time to warmup and capture the graph.
Compiled the graph.
generating: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 511/511 [00:04<00:00, 125.29it/s]
extracting geometry: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 170/170 [00:01<00:00, 118.28chunk/s]
Warp 1.6.2 initialized:
   CUDA Toolkit 12.8, Driver 12.4
   Devices:
     "cpu"      : "x86_64"
     "cuda:0"   : "NVIDIA H100 80GB HBM3" (79 GiB, sm_90, mempool enabled)
   Kernel cache:
    .cache/warp/1.6.2
Generated mesh for Broad-winged flying red dragon, elongated, folded legs. at `outputs/output.obj`
```
# Tested on a non-cuda device to hit the assert
```
cube$ python -m cube3d.generate             --gpt-ckpt-path model_weights/shape_gpt.safetensors             --shape-ckpt-path model_weights/shape_tokenizer.safetensors             --fast-inference             --prompt "Broad-winged flying red dragon, elongated, folded legs." --disable-postprocessing
WARNING:root:pymeshlab is not installed or could not be loaded. Please install it with `pip install pymeshlab`.
Using device: cpu
Using cuda graphs, this will take some time to warmup and capture the graph.
Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/conda/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/cube/cube3d/generate.py", line 122, in <module>
    engine = EngineFast(
  File "/cube/cube3d/inference/engine.py", line 308, in __init__
    device.type == "cuda"
AssertionError: EngineFast is only supported on cuda devices, please use Engine on non-cuda devices
```

## ✅ Checklist
- [x] Provide testing instructions
- [x] Update relevant documentation
