### PR TITLE
Add ROCm installation notes for CubePart

### DIFF
--- a/cubepart/README.md
+++ b/cubepart/README.md
@@ -34,6 +34,40 @@ pip install -e .
 pip install -r requirements.txt
 ```
 
+### ROCm / AMD GPU installation
+
+CubePart can also run in a ROCm PyTorch environment. The example below was
+tested with an AMD Instinct MI300X GPU on ROCm 6.4.3 using the official PyTorch
+ROCm container.
+
+```bash
+docker run --rm -it \
+    --device=/dev/kfd --device=/dev/dri --group-add video \
+    --ipc=host --shm-size=96G \
+    -v "$PWD":"$PWD" -w "$PWD/cubepart" \
+    rocm/pytorch:rocm6.4.3_ubuntu24.04_py3.12_pytorch_release_2.6.0 \
+    bash
+```
+
+Inside the container, keep the ROCm-enabled `torch` and `torchvision` wheels
+from the image, then install the ROCm helper requirements and the package:
+
+```bash
+pip install -r requirements_rocm.txt
+pip install "fpsample>=0.3" --no-build-isolation
+pip install -e . --no-build-isolation
+```
+
+If you use the repository example meshes, make sure Git LFS assets are present:
+
+```bash
+git lfs pull --include="cubepart/examples/inputs/jellyfish_car.glb"
+```
+
+ROCm note: `warp-lang` may not detect AMD GPUs as CUDA devices. In that case,
+geometry extraction can fall back to the CPU path and still export meshes, but
+this path is not expected to provide ROCm-native geometry extraction performance.
+
 ## Download model weights
 
 The pretrained checkpoints (multi-part DiT + shape VAE) are hosted on the

--- a/cubepart/requirements_rocm.txt
+++ b/cubepart/requirements_rocm.txt
@@ -1,0 +1,17 @@
+# ROCm helper requirements.
+#
+# Use this inside a ROCm PyTorch environment, for example:
+# rocm/pytorch:rocm6.4.3_ubuntu24.04_py3.12_pytorch_release_2.6.0
+#
+# This file intentionally does not install torch or torchvision; keep the
+# ROCm-enabled builds that are already provided by the container.
+
+scikit-build-core
+cmake
+ninja
+pybind11
+pybind11-global
+
+# Keep NumPy and scikit-image ABI-compatible in Python 3.12 ROCm containers.
+numpy==1.26.4
+scikit-image==0.25.2


### PR DESCRIPTION
## Summary

Add ROCm installation and inference notes for CubePart.

## Changes

- Document a ROCm PyTorch Docker setup for AMD GPUs.
- Add `requirements_rocm.txt` with helper build dependencies and NumPy/scikit-image pins.
- Note that example meshes require Git LFS assets.
- Document the current `warp-lang` geometry fallback caveat on ROCm.

## Tested on

- GPU: AMD Instinct MI300X / `gfx942`
- ROCm: 6.4.3
- PyTorch Docker: `rocm/pytorch:rocm6.4.3_ubuntu24.04_py3.12_pytorch_release_2.6.0`

## Results

- `pip install -r requirements_rocm.txt && pip install -e . --no-build-isolation` succeeded.
- `examples/run_inference.py` completed on `examples/inputs/jellyfish_car.glb`.
- A 50-step demo run exported 8 part meshes plus a combined `parts.glb`.

## Notes

- The ROCm instructions keep the container-provided ROCm `torch` and `torchvision` wheels.
- `warp-lang` may fall back during geometry extraction, but mesh export still completes.
