### PR TITLE
fix: package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ meshlab = ["pymeshlab"]
 lint = ["ruff==0.9.10"]
 
 [tool.setuptools.packages.find]
-where = ["cube3d"]
-include = ["cube/*"]
-namespaces = false
+where = ["."]
+include = ["cube3d*"]
+
+[tool.setuptools.package-data]
+cube3d = ["configs/*.yaml"]


### PR DESCRIPTION
This way the project can be installed e.g. using `pip install 'cube[meshlab] @ git+https://github.com/Roblox/cube'`. Useful for inclusion in e.g. `requirements.txt`.